### PR TITLE
quilt-tester: Increase wait time after detecting containers starting

### DIFF
--- a/quilt-tester.go
+++ b/quilt-tester.go
@@ -271,7 +271,7 @@ func (ts *testSuite) run() error {
 	}
 
 	// Wait a little bit longer for any container bootstrapping after boot.
-	time.Sleep(30 * time.Second)
+	time.Sleep(60 * time.Second)
 
 	var err error
 	if ts.test != "" {


### PR DESCRIPTION
With the move to Jenkins, a timing issue caused network tests to fail.
It was discovered that these errors were resolved when the test was
ran again at a later time, so the tester has been modified to wait
a little bit longer before running tests on a set of containers.