### PR TITLE
debug-logs: Count debug-logs as test artifacts

### DIFF
--- a/config/jenkins/job.xml
+++ b/config/jenkins/job.xml
@@ -49,7 +49,7 @@ tester --preserve-failed -testRoot=./tests -junitOut=${WORKSPACE}/report.xml</co
   </builders>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>*.log</artifacts>
+      <artifacts>*.log,*.tar</artifacts>
       <allowEmptyArchive>false</allowEmptyArchive>
       <onlyIfSuccessful>false</onlyIfSuccessful>
       <fingerprint>false</fingerprint>

--- a/quilt-tester.go
+++ b/quilt-tester.go
@@ -255,8 +255,7 @@ func (ts *testSuite) run() error {
 	}()
 	defer func() {
 		logsPath := filepath.Join(os.Getenv("WORKSPACE"), ts.name+"_debug_logs")
-		cmd := exec.Command("quilt", "debug-logs", "-tar=false",
-			"-o="+logsPath, "-all")
+		cmd := exec.Command("quilt", "debug-logs", "-o="+logsPath, "-all")
 		stdout, stderr, err := execCmd(cmd, "DEBUG LOGS")
 		if err != nil {
 			l.errorln(fmt.Sprintf("Debug logs encountered an error:"+


### PR DESCRIPTION
While the debug logs are currently output to the workspace, they
are not saved as test artifacts, so they're lost after the test
completes. This patch marks debug logs as testing artifacts so
jenkins saves them from run to run.