### PR TITLE
infrastructure: Move VMs to us-west-2

### DIFF
--- a/config/infrastructure.js
+++ b/config/infrastructure.js
@@ -5,7 +5,7 @@ function MachineDeployer(nWorker) {
 MachineDeployer.prototype.deploy = function(deployment) {
     var baseMachine = new Machine({
         provider: "Amazon",
-        region: "us-west-1",
+        region: "us-west-2",
         preemptible: true,
         sshKeys: ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCxMuzNUdKJREFgUkSpD0OPjtgDtbDvHQLDxgqnTrZpSvTw5r8XDd+AFS6eVibBfYv1u+geNF3IEkpOklDlII37DzhW7wzlRB0SmjUtODxL5hf9hKoScDpvXG3RBD6PBCyOHA5IJBTqPGpIZUMmOlXDYZA1KLaKQs6GByg7QMp6z1/gLCgcQygTDdiTfESgVMwR1uSQ5MRjBaL7vcVfrKExyCLxito77lpWFMARGG9W1wTWnmcPrzYR7cLzhzUClakazNJmfso/b4Y5m+pNH2dLZdJ/eieLtSEsBDSP8X0GYpmTyFabZycSXZFYP+wBkrUTmgIh9LQ56U1lvA4UlxHJ"],
     });


### PR DESCRIPTION
For some reason spot requests appear not to be working in us-west-1,
but when I tested manually they're fine in us-west-2.  For now, we'll
move the tester over.