### PR TITLE
infrastructure: Switch back to reserved instances

### DIFF
--- a/config/infrastructure.js
+++ b/config/infrastructure.js
@@ -6,7 +6,7 @@ MachineDeployer.prototype.deploy = function(deployment) {
     var baseMachine = new Machine({
         provider: "Amazon",
         region: "us-west-2",
-        preemptible: true,
+        preemptible: false,
         sshKeys: ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCxMuzNUdKJREFgUkSpD0OPjtgDtbDvHQLDxgqnTrZpSvTw5r8XDd+AFS6eVibBfYv1u+geNF3IEkpOklDlII37DzhW7wzlRB0SmjUtODxL5hf9hKoScDpvXG3RBD6PBCyOHA5IJBTqPGpIZUMmOlXDYZA1KLaKQs6GByg7QMp6z1/gLCgcQygTDdiTfESgVMwR1uSQ5MRjBaL7vcVfrKExyCLxito77lpWFMARGG9W1wTWnmcPrzYR7cLzhzUClakazNJmfso/b4Y5m+pNH2dLZdJ/eieLtSEsBDSP8X0GYpmTyFabZycSXZFYP+wBkrUTmgIh9LQ56U1lvA4UlxHJ"],
     });
 


### PR DESCRIPTION
Preemptible instances have been broken for quite a while. Switching
back to reserved so at least some of our tests pass until they've been
fixed.