### PR TITLE
quilt-tester: Don't tar debug-logs

### DIFF
--- a/config/jenkins/job.xml
+++ b/config/jenkins/job.xml
@@ -49,7 +49,7 @@ tester --preserve-failed -testRoot=./tests -junitOut=${WORKSPACE}/report.xml</co
   </builders>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>*.log,*.tar</artifacts>
+      <artifacts>*.log,*_debug_logs/**/*</artifacts>
       <allowEmptyArchive>false</allowEmptyArchive>
       <onlyIfSuccessful>false</onlyIfSuccessful>
       <fingerprint>false</fingerprint>

--- a/quilt-tester.go
+++ b/quilt-tester.go
@@ -255,7 +255,7 @@ func (ts *testSuite) run() error {
 	}()
 	defer func() {
 		logsPath := filepath.Join(os.Getenv("WORKSPACE"), ts.name+"_debug_logs")
-		cmd := exec.Command("quilt", "debug-logs", "-o="+logsPath, "-all")
+		cmd := exec.Command("quilt", "debug-logs", "-tar=false", "-o="+logsPath, "-all")
 		stdout, stderr, err := execCmd(cmd, "DEBUG LOGS")
 		if err != nil {
 			l.errorln(fmt.Sprintf("Debug logs encountered an error:"+


### PR DESCRIPTION
This way we can view the logs directly through the browser, rather than
downloading and untarring the logs.