### PR TITLE
Revert "quilt-tester: Increase wait time after detecting containers s…

### DIFF
--- a/quilt-tester.go
+++ b/quilt-tester.go
@@ -280,7 +280,7 @@ func (ts *testSuite) run() error {
 	}
 
 	// Wait a little bit longer for any container bootstrapping after boot.
-	time.Sleep(120 * time.Second)
+	time.Sleep(30 * time.Second)
 
 	var err error
 	if ts.test != "" {


### PR DESCRIPTION
…tarting"

This reverts commit 47bbb6e86ded76df21a49386a7a99df7efc3512b and
22b761d653f5ecd6ada8cda5573052f7f321d0cc. Increasing the wait time
didn't actually fix the network test.