### PR TITLE
spark: Give Spark job extra time to run

### DIFF
--- a/tests/20-spark/check_spark.go
+++ b/tests/20-spark/check_spark.go
@@ -35,15 +35,13 @@ func main() {
 	fmt.Println(string(containersPretty))
 
 	var id string
-	failed := true
 	for _, dbc := range containers {
 		if strings.Join(dbc.Command, " ") == "run master" {
-			id = fmt.Sprint(dbc.StitchID)
-			failed = false
-			println("found id ", id)
+			id = dbc.StitchID
+			break
 		}
 	}
-	if failed {
+	if id == "" {
 		log.Fatal("FAILED, unable to find StitchID of Spark master.")
 	}
 


### PR DESCRIPTION
There was an integration test failure where the Spark job had not
completed when we ran the check, but was finished when we ran `quilt
debug-logs` during teardown.