### PR TITLE
Test all providers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkinsci/jenkins:2.49
+FROM jenkinsci/jenkins:2.60
 
 USER root
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ USER jenkins
 ADD config/id_rsa /var/jenkins_home/.ssh/id_rsa
 
 RUN /usr/local/bin/install-plugins.sh golang ws-cleanup timestamper slack \
-    test-results-analyzer git claim nodejs
+    test-results-analyzer git claim nodejs parameterized-scheduler show-build-parameters
 
 # XXX: We unset the Entrypoint so that specs can run arbitrary commands (such
 # as `bash`) to initialize the container. This is necessary to properly write

--- a/README.md
+++ b/README.md
@@ -17,8 +17,17 @@ configuration options to be passed in by the caller. An example is included at
 [tester-runner-example.js](tester-runner-example.js).
 
 The required configurations are:
-- `awsAccessKey`: The access key used by test daemon to boot machines.
-- `awsSecretAccessKey`: The secret access key used by test daemon to boot machines.
+- `awsAccessKey`: The access key used by the test daemon to boot machines on
+the Amazon provider.
+- `awsSecretAccessKey`: The secret access key used by the test daemon to boot
+machines on the Amazon provider.
+- `digitalOceanKey`: The secret key used to boot machines on the DigitalOcean
+provider.
+- `gceProjectID`: The ID of the project in which Google machines will be booted.
+- `gcePrivateKey`: The private key of the service account used to boot machines
+on the Google provider.
+- `gceClientEmail`: The email address of the service account used to boot
+machines on the Google provider.
 - `testingNamespace`: The namespace used by the test daemon.
 - `slackChannel`: The Slack channel where build results will be posted.
 - `slackTeam`: The Slack team in which `slackChannel` is located.

--- a/config/gce.json.tmpl
+++ b/config/gce.json.tmpl
@@ -1,0 +1,5 @@
+{
+  "project_id": "{{gceProjectID}}",
+  "private_key": "{{gcePrivateKey}}",
+  "client_email": "{{gceClientEmail}}"
+}

--- a/config/infrastructure.js
+++ b/config/infrastructure.js
@@ -6,15 +6,19 @@ function MachineDeployer(nWorker) {
 
 MachineDeployer.prototype.deploy = function(deployment) {
     var baseMachine = new Machine({
-        provider: "Amazon",
-        region: "us-west-1",
+        provider: process.env.PROVIDER || "Amazon",
+        size: process.env.SIZE || "m3.medium",
         sshKeys: ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCxMuzNUdKJREFgUkSpD0OPjtgDtbDvHQLDxgqnTrZpSvTw5r8XDd+AFS6eVibBfYv1u+geNF3IEkpOklDlII37DzhW7wzlRB0SmjUtODxL5hf9hKoScDpvXG3RBD6PBCyOHA5IJBTqPGpIZUMmOlXDYZA1KLaKQs6GByg7QMp6z1/gLCgcQygTDdiTfESgVMwR1uSQ5MRjBaL7vcVfrKExyCLxito77lpWFMARGG9W1wTWnmcPrzYR7cLzhzUClakazNJmfso/b4Y5m+pNH2dLZdJ/eieLtSEsBDSP8X0GYpmTyFabZycSXZFYP+wBkrUTmgIh9LQ56U1lvA4UlxHJ"],
     });
 
     deployment.deploy(baseMachine.asMaster());
 
     var worker = baseMachine.asWorker();
-    worker.preemptible = true;
+    // Preemptible instances are currently only implemented on Amazon.
+    if (baseMachine.provider === "Amazon") {
+        worker.preemptible = true;
+    }
+
     deployment.deploy(worker.replicate(this.nWorker));
 }
 

--- a/config/jenkins/job.xml
+++ b/config/jenkins/job.xml
@@ -3,7 +3,28 @@
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
-  <properties/>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>PROVIDER</name>
+          <description>The provider to use for the test run.</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>Amazon</string>
+              <string>DigitalOcean</string>
+              <string>Google</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>SIZE</name>
+          <description>The machine size to use for the test run.</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
   <scm class="hudson.plugins.git.GitSCM" plugin="git@3.1.0">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
@@ -29,9 +50,12 @@
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers>
-    <hudson.triggers.TimerTrigger>
-      <spec>0 * * * *</spec>
-    </hudson.triggers.TimerTrigger>
+    <org.jenkinsci.plugins.parameterizedscheduler.ParameterizedTimerTrigger plugin="parameterized-scheduler@0.4">
+      <spec></spec>
+      <parameterizedSpecification>0 0-23/3 * * * %PROVIDER=Amazon;SIZE=m3.medium
+0 1-23/3 * * * %PROVIDER=Google;SIZE=n1-standard-1
+0 2-23/3 * * * %PROVIDER=DigitalOcean;SIZE=1gb</parameterizedSpecification>
+    </org.jenkinsci.plugins.parameterizedscheduler.ParameterizedTimerTrigger>
   </triggers>
   <concurrentBuild>false</concurrentBuild>
   <builders>

--- a/tester.js
+++ b/tester.js
@@ -13,7 +13,7 @@ exports.New = function(opts) {
 
     var container = new Container("quilt/tester",
         ["/bin/bash", "-c",
-            "cp -r " + jenkinsStagingDir + "* /var/jenkins_home;" +
+            "cp -r " + jenkinsStagingDir + ". /var/jenkins_home;" +
             "/bin/tini -s -- /usr/local/bin/jenkins.sh"]);
     container.setEnv("AWS_ACCESS_KEY", opts.awsAccessKey);
     container.setEnv("AWS_SECRET_ACCESS_KEY", opts.awsSecretAccessKey);

--- a/tester.js
+++ b/tester.js
@@ -9,7 +9,12 @@ const path = require('path');
 var jenkinsStagingDir = "/tmp/files/"
 
 exports.New = function(opts) {
-    assertRequiredParameters(opts, ["awsAccessKey", "awsSecretAccessKey", "testingNamespace", "slackTeam", "slackChannel", "slackToken"]);
+    assertRequiredParameters(opts, [
+        "awsAccessKey", "awsSecretAccessKey",
+        "digitalOceanKey",
+        "gceProjectID", "gcePrivateKey", "gceClientEmail",
+        "testingNamespace",
+        "slackTeam", "slackChannel", "slackToken"]);
 
     var container = new Container("quilt/tester",
         ["/bin/bash", "-c",
@@ -40,6 +45,15 @@ exports.New = function(opts) {
 
 function setupFiles(jenkins, opts) {
     var files = [];
+
+    files.push(new File(".digitalocean/key", opts.digitalOceanKey));
+
+    var gceConfig = new File(".gce/quilt.json",
+        applyTemplate(readRel("config/gce.json.tmpl"),
+            {gceProjectID: opts.gceProjectID,
+             gcePrivateKey: opts.gcePrivateKey,
+             gceClientEmail: opts.gceClientEmail}));
+    files.push(gceConfig);
 
     var rootConfig = new File("config.xml", readRel("config/jenkins/root.xml"));
     files.push(rootConfig);


### PR DESCRIPTION
This patch modifies the quilt-tester spec to install credentials for
DigitalOcean and Google (in addition to Amazon), and rotate providers
every hour.