### PR TITLE
example: Add missing parameters to tester constructor

### DIFF
--- a/tester-runner-example.js
+++ b/tester-runner-example.js
@@ -17,6 +17,10 @@ deployment.deploy(worker);
 deployment.deploy(tester.New({
     awsAccessKey: "accessKey",
     awsSecretAccessKey: "secret",
+    gceProjectID: "projectID",
+    gcePrivateKey: "privateKey",
+    gceClientEmail: "email",
+    digitalOceanKey: "key",
     testingNamespace: "quilt-tester",
     slackTeam: "quilt-dev",
     slackChannel: "#testing",


### PR DESCRIPTION
The example spec was failing to compile because some required parameters
were missing.