### PR TITLE
jenkins: Test Travis-built Quilt binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ USER jenkins
 ADD config/id_rsa /var/jenkins_home/.ssh/id_rsa
 
 RUN /usr/local/bin/install-plugins.sh golang ws-cleanup timestamper slack \
-    test-results-analyzer git claim nodejs parameterized-scheduler show-build-parameters
+    test-results-analyzer claim nodejs parameterized-scheduler show-build-parameters
 
 # XXX: We unset the Entrypoint so that specs can run arbitrary commands (such
 # as `bash`) to initialize the container. This is necessary to properly write

--- a/config/jenkins/job.xml
+++ b/config/jenkins/job.xml
@@ -25,26 +25,6 @@
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@3.1.0">
-    <configVersion>2</configVersion>
-    <userRemoteConfigs>
-      <hudson.plugins.git.UserRemoteConfig>
-        <url>https://github.com/quilt/quilt</url>
-      </hudson.plugins.git.UserRemoteConfig>
-    </userRemoteConfigs>
-    <branches>
-      <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
-      </hudson.plugins.git.BranchSpec>
-    </branches>
-    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
-    <submoduleCfg class="list"/>
-    <extensions>
-      <hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
-        <relativeTargetDir>gohome/src/github.com/quilt/quilt</relativeTargetDir>
-      </hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
-    </extensions>
-  </scm>
   <canRoam>true</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
@@ -60,10 +40,13 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>export GOPATH=${WORKSPACE}/gohome
-export PATH=${GOPATH}/bin:${PATH}
+      <command>mkdir ${WORKSPACE}/bin
+curl -sL -o ${WORKSPACE}/bin/quilt https://github.com/quilt/quilt/releases/download/dev/quilt_linux
+chmod 755 ${WORKSPACE}/bin/quilt
 
-go install -v github.com/quilt/quilt
+export GOPATH=${WORKSPACE}/gohome
+export PATH=${GOPATH}/bin:${WORKSPACE}/bin:${PATH}
+
 go get -v github.com/quilt/tester
 
 cd $GOPATH/src/github.com/quilt/tester


### PR DESCRIPTION
Before, the Jenkins job cloned the Quilt repo, and built it locally. We
now download the Quilt binary that Travis builds, and test that.

This will make it easier to test different Quilt releases because we
will simply have to change the binary that we download. Furthermore,
this avoids potential errors where Travis builds a slightly different
binary than Jenkins.