### PR TITLE
jenkins: Increase instance size for DigitalOcean

### DIFF
--- a/config/jenkins/job.xml
+++ b/config/jenkins/job.xml
@@ -54,7 +54,7 @@
       <spec></spec>
       <parameterizedSpecification>0 0-23/3 * * * %PROVIDER=Amazon;SIZE=m3.medium
 0 1-23/3 * * * %PROVIDER=Google;SIZE=n1-standard-1
-0 2-23/3 * * * %PROVIDER=DigitalOcean;SIZE=1gb</parameterizedSpecification>
+0 2-23/3 * * * %PROVIDER=DigitalOcean;SIZE=2gb</parameterizedSpecification>
     </org.jenkinsci.plugins.parameterizedscheduler.ParameterizedTimerTrigger>
   </triggers>
   <concurrentBuild>false</concurrentBuild>


### PR DESCRIPTION
The 1gb size was running out of memory when running the Spark tests. This
commit increases the size to have 2gb of memory.