### PR TITLE
jenkins: Show the version and provider in the build history

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ USER jenkins
 ADD config/id_rsa /var/jenkins_home/.ssh/id_rsa
 
 RUN /usr/local/bin/install-plugins.sh golang ws-cleanup timestamper slack \
-    test-results-analyzer claim nodejs parameterized-scheduler show-build-parameters
+    test-results-analyzer claim nodejs parameterized-scheduler show-build-parameters \
+    groovy-postbuild
+
 
 # XXX: We unset the Entrypoint so that specs can run arbitrary commands (such
 # as `bash`) to initialize the container. This is necessary to properly write

--- a/config/jenkins/job.xml
+++ b/config/jenkins/job.xml
@@ -68,6 +68,15 @@ tester --preserve-failed -testRoot=./tests -junitOut=${WORKSPACE}/report.xml</co
       <defaultExcludes>true</defaultExcludes>
       <caseSensitive>true</caseSensitive>
     </hudson.tasks.ArtifactArchiver>
+    <org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder plugin="groovy-postbuild@2.3.1">
+      <script plugin="script-security@1.27">
+        <script>manager.addShortText(&quot;${manager.build.buildVariables.get(&apos;QUILT_VERSION&apos;)}&quot;)
+manager.addShortText(&quot;${manager.build.buildVariables.get(&apos;PROVIDER&apos;)}&quot;)</script>
+        <sandbox>false</sandbox>
+      </script>
+      <behavior>0</behavior>
+      <runForMatrixParent>false</runForMatrixParent>
+    </org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder>
     <hudson.tasks.junit.JUnitResultArchiver plugin="junit@1.20">
       <testResults>report.xml</testResults>
       <keepLongStdio>true</keepLongStdio>

--- a/config/jenkins/scriptApproval.xml
+++ b/config/jenkins/scriptApproval.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<scriptApproval plugin="script-security@1.27">
+  <approvedScriptHashes>
+    <string>21b44d1bf94eb9303fcde6ca1258b004423a08b2</string>
+  </approvedScriptHashes>
+  <approvedSignatures/>
+  <aclApprovedSignatures/>
+  <approvedClasspathEntries/>
+  <pendingScripts/>
+  <pendingSignatures/>
+  <pendingClasspathEntries/>
+</scriptApproval>

--- a/tester.js
+++ b/tester.js
@@ -58,6 +58,9 @@ function setupFiles(jenkins, opts) {
     var rootConfig = new File("config.xml", readRel("config/jenkins/root.xml"));
     files.push(rootConfig);
 
+    var scriptConfig = new File("scriptApproval.xml", readRel("config/jenkins/scriptApproval.xml"));
+    files.push(scriptConfig);
+
     var goConfig = new File("org.jenkinsci.plugins.golang.GolangBuildWrapper.xml",
         readRel("config/jenkins/go.xml"));
     files.push(goConfig);


### PR DESCRIPTION
This makes it much easier to notice trends at a glance in the Build
History view.