### PR TITLE
tester: Increase timeout to allow hostname propagation

### DIFF
--- a/quilt-tester.go
+++ b/quilt-tester.go
@@ -276,7 +276,7 @@ func (ts *testSuite) run() error {
 	}
 
 	// Wait a little bit longer for any container bootstrapping after boot.
-	time.Sleep(30 * time.Second)
+	time.Sleep(90 * time.Second)
 
 	var err error
 	if ts.test != "" {


### PR DESCRIPTION
Some tests seem to be failing on the DigitalOcean provider because
hostnames are not yet resolvable. While not a proper solution, this
patch increases the wait time to see if the failure rate decreases.