### PR TITLE
logs: Don't fail on DNS request debug output

### DIFF
--- a/tests/100-logs/check_logs.go
+++ b/tests/100-logs/check_logs.go
@@ -43,9 +43,12 @@ func main() {
 
 		// "goroutine 0" is the main goroutine, and is thus always printed in
 		// stacktraces.
+		// The trailing open bracket is necessary to filter out false positives
+		// in the log output. For example, as part of logging DNS requests, the
+		// status string NOERROR is printed.
 		if strings.Contains(outputStr, "goroutine 0") ||
-			strings.Contains(outputStr, "ERROR") ||
-			strings.Contains(outputStr, "WARN") {
+			strings.Contains(outputStr, "ERROR [") ||
+			strings.Contains(outputStr, "WARN [") {
 			failed = true
 		}
 	}


### PR DESCRIPTION
As part of logging DNS requests, the status string NOERROR is printed.
This commit modifies the log failure test to include the open bracket
printed by logrus before the timestamp.

For example, we will no longer match:
```
DEBUG [Jun  9 22:12:57.563] DNS Request: ;; opcode: QUERY, status: NOERROR, id: 53324
```

But will still match:
```
ERROR [Jun  9 22:12:57.563] Something failed
```