### PR TITLE
tests: Set log format to include formatted time

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -1,0 +1,9 @@
+package formatter
+
+import (
+	"github.com/Sirupsen/logrus"
+)
+
+var Formatter = &logrus.TextFormatter{
+	FullTimestamp: true,
+}

--- a/tests/10-network/check_network.go
+++ b/tests/10-network/check_network.go
@@ -16,6 +16,7 @@ import (
 	"github.com/quilt/quilt/api/client/getter"
 	"github.com/quilt/quilt/db"
 	"github.com/quilt/quilt/join"
+	"github.com/quilt/tester/formatter"
 )
 
 // anyIPAllowed is used to indicate that any non-error response is okay for an external
@@ -44,6 +45,7 @@ type testResult struct {
 }
 
 func main() {
+	log.SetFormatter(formatter.Formatter)
 	clientGetter := getter.New()
 
 	clnt, err := clientGetter.Client(api.DefaultSocket)

--- a/tests/100-logs/check_logs.go
+++ b/tests/100-logs/check_logs.go
@@ -10,11 +10,14 @@ import (
 
 	"github.com/quilt/quilt/api"
 	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/tester/formatter"
 )
 
 var machineRegex = regexp.MustCompile(`Machine-(\d+){(.+?), .*, PublicIP=(.*?),`)
 
 func main() {
+	log.SetFormatter(formatter.Formatter)
+
 	printQuiltPs()
 
 	c, err := getter.New().Client(api.DefaultSocket)

--- a/tests/15-bandwidth/check_bandwidth.go
+++ b/tests/15-bandwidth/check_bandwidth.go
@@ -14,6 +14,7 @@ import (
 	"github.com/quilt/quilt/api"
 	"github.com/quilt/quilt/api/client/getter"
 	"github.com/quilt/quilt/db"
+	"github.com/quilt/tester/formatter"
 )
 
 // The required bandwidth in Mb/s between two containers on different machines.
@@ -30,6 +31,8 @@ type testResult struct {
 }
 
 func main() {
+	log.SetFormatter(formatter.Formatter)
+
 	clientGetter := getter.New()
 
 	clnt, err := clientGetter.Client(api.DefaultSocket)

--- a/tests/20-spark/check_spark.go
+++ b/tests/20-spark/check_spark.go
@@ -11,9 +11,12 @@ import (
 	"github.com/quilt/quilt/api"
 	"github.com/quilt/quilt/api/client/getter"
 	"github.com/quilt/quilt/util"
+	"github.com/quilt/tester/formatter"
 )
 
 func main() {
+	log.SetFormatter(formatter.Formatter)
+
 	clientGetter := getter.New()
 
 	clnt, err := clientGetter.Client(api.DefaultSocket)

--- a/tests/30-mean/check_mean.go
+++ b/tests/30-mean/check_mean.go
@@ -11,6 +11,7 @@ import (
 	"github.com/quilt/quilt/api"
 	"github.com/quilt/quilt/api/client/getter"
 	"github.com/quilt/quilt/db"
+	"github.com/quilt/tester/formatter"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -23,6 +24,8 @@ type Response struct {
 }
 
 func main() {
+	log.SetFormatter(formatter.Formatter)
+
 	clientGetter := getter.New()
 
 	clnt, err := clientGetter.Client(api.DefaultSocket)

--- a/tests/40-stop/check_stop.go
+++ b/tests/40-stop/check_stop.go
@@ -9,11 +9,14 @@ import (
 	"github.com/quilt/quilt/api"
 	"github.com/quilt/quilt/api/client/getter"
 	"github.com/quilt/quilt/minion/supervisor/images"
+	"github.com/quilt/tester/formatter"
 
 	log "github.com/Sirupsen/logrus"
 )
 
 func main() {
+	log.SetFormatter(formatter.Formatter)
+
 	if err := exec.Command("quilt", "stop", "-containers").Run(); err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't run stop command")
 	}

--- a/tests/61-duplicate-cluster/check_duplicate_cluster.go
+++ b/tests/61-duplicate-cluster/check_duplicate_cluster.go
@@ -10,11 +10,14 @@ import (
 
 	"github.com/quilt/quilt/api"
 	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/tester/formatter"
 )
 
 var connectionRegex = regexp.MustCompile(`Registering worker (\d+\.\d+\.\d+\.\d+:\d+)`)
 
 func main() {
+	log.SetFormatter(formatter.Formatter)
+
 	clientGetter := getter.New()
 
 	clnt, err := clientGetter.Client(api.DefaultSocket)

--- a/tests/build-dockerfile/check_custom_images.go
+++ b/tests/build-dockerfile/check_custom_images.go
@@ -9,11 +9,14 @@ import (
 	"github.com/quilt/quilt/api"
 	"github.com/quilt/quilt/api/client/getter"
 	"github.com/quilt/quilt/db"
+	"github.com/quilt/tester/formatter"
 
 	log "github.com/Sirupsen/logrus"
 )
 
 func main() {
+	log.SetFormatter(formatter.Formatter)
+
 	clientGetter := getter.New()
 
 	clnt, err := clientGetter.Client(api.DefaultSocket)

--- a/tests/elasticsearch/check_elasticsearch.go
+++ b/tests/elasticsearch/check_elasticsearch.go
@@ -13,11 +13,14 @@ import (
 	"github.com/quilt/quilt/api"
 	"github.com/quilt/quilt/api/client/getter"
 	"github.com/quilt/quilt/db"
+	"github.com/quilt/tester/formatter"
 
 	log "github.com/Sirupsen/logrus"
 )
 
 func main() {
+	log.SetFormatter(formatter.Formatter)
+
 	clientGetter := getter.New()
 
 	clnt, err := clientGetter.Client(api.DefaultSocket)

--- a/tests/etcd/check_etcd.go
+++ b/tests/etcd/check_etcd.go
@@ -8,11 +8,14 @@ import (
 	"github.com/quilt/quilt/api"
 	"github.com/quilt/quilt/api/client/getter"
 	"github.com/quilt/quilt/db"
+	"github.com/quilt/tester/formatter"
 
 	log "github.com/Sirupsen/logrus"
 )
 
 func main() {
+	log.SetFormatter(formatter.Formatter)
+
 	clientGetter := getter.New()
 
 	clnt, err := clientGetter.Client(api.DefaultSocket)

--- a/tests/inbound-public/check_inbound_public.go
+++ b/tests/inbound-public/check_inbound_public.go
@@ -8,11 +8,14 @@ import (
 	"github.com/quilt/quilt/api"
 	"github.com/quilt/quilt/api/client/getter"
 	"github.com/quilt/quilt/db"
+	"github.com/quilt/tester/formatter"
 
 	log "github.com/Sirupsen/logrus"
 )
 
 func main() {
+	log.SetFormatter(formatter.Formatter)
+
 	clientGetter := getter.New()
 
 	clnt, err := clientGetter.Client(api.DefaultSocket)

--- a/tests/load-balancer/check_load_balancer.go
+++ b/tests/load-balancer/check_load_balancer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/quilt/quilt/api"
 	"github.com/quilt/quilt/api/client/getter"
 	"github.com/quilt/quilt/db"
+	"github.com/quilt/tester/formatter"
 )
 
 const (
@@ -17,6 +18,8 @@ const (
 )
 
 func main() {
+	log.SetFormatter(formatter.Formatter)
+
 	c, err := getter.New().Client(api.DefaultSocket)
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't get local client")

--- a/tests/outbound-public/check_outbound_public.go
+++ b/tests/outbound-public/check_outbound_public.go
@@ -8,11 +8,14 @@ import (
 	"github.com/quilt/quilt/api/client/getter"
 	"github.com/quilt/quilt/db"
 	"github.com/quilt/quilt/stitch"
+	"github.com/quilt/tester/formatter"
 
 	log "github.com/Sirupsen/logrus"
 )
 
 func main() {
+	log.SetFormatter(formatter.Formatter)
+
 	clientGetter := getter.New()
 
 	clnt, err := clientGetter.Client(api.DefaultSocket)

--- a/tests/zookeeper/check_zookeeper.go
+++ b/tests/zookeeper/check_zookeeper.go
@@ -8,12 +8,15 @@ import (
 	"github.com/quilt/quilt/api"
 	"github.com/quilt/quilt/api/client/getter"
 	"github.com/quilt/quilt/db"
+	"github.com/quilt/tester/formatter"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/satori/go.uuid"
 )
 
 func main() {
+	log.SetFormatter(formatter.Formatter)
+
 	clientGetter := getter.New()
 
 	clnt, err := clientGetter.Client(api.DefaultSocket)


### PR DESCRIPTION
This commit modifies all tests to log with a human-readable timestamp.
This makes it much easier to debug test outputs.