### PR TITLE
tests: Add test for load balancing

### DIFF
--- a/tests/load-balancer/check_load_balancer.go
+++ b/tests/load-balancer/check_load_balancer.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/quilt/quilt/api"
+	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/quilt/db"
+)
+
+const (
+	fetcherLabel      = "fetcher"
+	loadBalancedLabel = "loadBalanced"
+)
+
+func main() {
+	c, err := getter.New().Client(api.DefaultSocket)
+	if err != nil {
+		log.WithError(err).Fatal("FAILED, couldn't get local client")
+	}
+	defer c.Close()
+
+	leaderClient, err := getter.New().LeaderClient(c)
+	if err != nil {
+		log.WithError(err).Fatal("FAILED, couldn't get leader client")
+	}
+	defer leaderClient.Close()
+
+	containers, err := leaderClient.QueryContainers()
+	if err != nil {
+		log.WithError(err).Fatal("FAILED, couldn't get containers")
+	}
+
+	var loadBalancedContainers []db.Container
+	var fetcherID string
+	for _, c := range containers {
+		if contains(c.Labels, fetcherLabel) {
+			fetcherID = c.StitchID
+		}
+		if contains(c.Labels, loadBalancedLabel) {
+			loadBalancedContainers = append(loadBalancedContainers, c)
+		}
+	}
+	log.WithField("expected unique responses", len(loadBalancedContainers)).Info("Starting fetching..")
+
+	if fetcherID == "" {
+		log.Fatal("FAILED, couldn't find fetcher")
+	}
+
+	loadBalancedCounts := map[string]int{}
+	for i := 0; i < len(loadBalancedContainers)*5; i++ {
+		outBytes, err := exec.Command("quilt", "ssh", fetcherID,
+			"wget", "-q", "-O", "-", loadBalancedLabel+".q").
+			CombinedOutput()
+		if err != nil {
+			log.WithError(err).Fatal("Unable to GET")
+		}
+
+		loadBalancedCounts[strings.TrimSpace(string(outBytes))]++
+	}
+
+	log.WithField("counts", loadBalancedCounts).Info("Fetching completed")
+	if len(loadBalancedCounts) < len(loadBalancedContainers) {
+		log.Fatal("FAILED, some containers not load balanced")
+	}
+	log.Info("PASSED")
+}
+
+func contains(lst []string, key string) bool {
+	for _, v := range lst {
+		if v == key {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/load-balancer/load-balancer.js
+++ b/tests/load-balancer/load-balancer.js
@@ -1,0 +1,18 @@
+const {createDeployment, Container, Service} = require("@quilt/quilt");
+var infrastructure = require("../../config/infrastructure.js")
+
+var deployment = createDeployment({});
+deployment.deploy(infrastructure);
+
+var containers = [];
+for (var i = 0 ; i < 4 ; i++) {
+  containers.push(new Container("nginx:1.10").withFiles({
+    '/usr/share/nginx/html/index.html': "I am container number " + i.toString() + "\n",
+  }));
+}
+
+var fetcher = new Service("fetcher", [new Container("alpine", ["tail", "-f", "/dev/null"])]);
+var loadBalanced = new Service("loadBalanced", containers);
+loadBalanced.allowFrom(fetcher, 80);
+
+deployment.deploy([fetcher, loadBalanced]);


### PR DESCRIPTION
This commit adds a test that creates a load-balanced set of containers
that each serve a unique page, and ensures that fetching the
load-balanced IP repeatedly results in different responses.