### PR TITLE
mean: Fix connect method

### DIFF
--- a/tests/30-mean/mean.js
+++ b/tests/30-mean/mean.js
@@ -18,8 +18,8 @@ var app = new Node({
 });
 var haproxy = new HaProxy(3, app.services());
 
-app.allowFrom(mongo, mongo.port);
-mongo.allowFrom(app, mongo.port);
+mongo.connect(mongo.port, app);
+app.connect(mongo.port, mongo);
 haproxy.public();
 
 deployment.deploy(app);


### PR DESCRIPTION
A previous commit changed instances of `Service.connect` to
`Service.allowFrom`. However, the `connect`s in the MEAN spec are
methods exposed by objects, not `Service.connect`s. Thus, `allowFrom`
is not defined on these objects.