### PR TITLE
quilt-tester: Update to latest API for getting Quilt clients

### DIFF
--- a/quilt-tester.go
+++ b/quilt-tester.go
@@ -15,8 +15,9 @@ import (
 	"github.com/Sirupsen/logrus"
 
 	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
-	apiUtil "github.com/quilt/quilt/api/util"
+	"github.com/quilt/quilt/api/client"
+	"github.com/quilt/quilt/db"
+	"github.com/quilt/quilt/join"
 	"github.com/quilt/quilt/stitch"
 	"github.com/quilt/quilt/util"
 )
@@ -302,25 +303,29 @@ func waitForContainers(blueprintPath string) error {
 		return err
 	}
 
-	localClient, err := getter.New().Client(api.DefaultSocket)
+	c, err := client.New(api.DefaultSocket)
 	if err != nil {
 		return err
 	}
+	defer c.Close()
 
 	return util.WaitFor(func() bool {
-		for _, exp := range stc.Containers {
-			containerClient, err := getter.New().ContainerClient(localClient,
-				exp.ID)
-			if err != nil {
-				return false
-			}
-
-			actual, err := apiUtil.GetContainer(containerClient, exp.ID)
-			if err != nil || actual.Created.IsZero() {
-				return false
-			}
+		curr, err := c.QueryContainers()
+		if err != nil {
+			return false
 		}
-		return true
+
+		// Only match containers that have the same stitch ID, and have been booted.
+		key := func(tgtIntf, actualIntf interface{}) int {
+			tgt := tgtIntf.(stitch.Container)
+			actual := actualIntf.(db.Container)
+			if tgt.ID == actual.StitchID && !actual.Created.IsZero() {
+				return 0
+			}
+			return -1
+		}
+		_, unbooted, _ := join.Join(stc.Containers, curr, key)
+		return len(unbooted) == 0
 	}, 15*time.Second, 10*time.Minute)
 }
 

--- a/tests/10-network/check_network.go
+++ b/tests/10-network/check_network.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/quilt/quilt/api"
 	"github.com/quilt/quilt/api/client"
-	"github.com/quilt/quilt/api/client/getter"
 	"github.com/quilt/quilt/db"
 	"github.com/quilt/quilt/join"
 )
@@ -44,25 +43,18 @@ type testResult struct {
 }
 
 func main() {
-	clientGetter := getter.New()
-
-	clnt, err := clientGetter.Client(api.DefaultSocket)
+	clnt, err := client.New(api.DefaultSocket)
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't get quiltctl client")
 	}
 	defer clnt.Close()
 
-	leader, err := clientGetter.LeaderClient(clnt)
-	if err != nil {
-		log.WithError(err).Fatal("FAILED, couldn't get leader client")
-	}
-
-	tester, err := newNetworkTester(leader)
+	tester, err := newNetworkTester(clnt)
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't initialize network tester")
 	}
 
-	containers, err := leader.QueryContainers()
+	containers, err := clnt.QueryContainers()
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't query containers")
 	}

--- a/tests/100-logs/check_logs.go
+++ b/tests/100-logs/check_logs.go
@@ -9,7 +9,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/quilt/api/client"
 )
 
 var machineRegex = regexp.MustCompile(`Machine-(\d+){(.+?), .*, PublicIP=(.*?),`)
@@ -17,7 +17,7 @@ var machineRegex = regexp.MustCompile(`Machine-(\d+){(.+?), .*, PublicIP=(.*?),`
 func main() {
 	printQuiltPs()
 
-	c, err := getter.New().Client(api.DefaultSocket)
+	c, err := client.New(api.DefaultSocket)
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't get quiltctl client")
 	}

--- a/tests/15-bandwidth/check_bandwidth.go
+++ b/tests/15-bandwidth/check_bandwidth.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/quilt/api/client"
 	"github.com/quilt/quilt/db"
 )
 
@@ -30,20 +30,13 @@ type testResult struct {
 }
 
 func main() {
-	clientGetter := getter.New()
-
-	clnt, err := clientGetter.Client(api.DefaultSocket)
+	clnt, err := client.New(api.DefaultSocket)
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't get quiltctl client")
 	}
 	defer clnt.Close()
 
-	leader, err := clientGetter.LeaderClient(clnt)
-	if err != nil {
-		log.WithError(err).Fatal("FAILED, couldn't get leader client")
-	}
-
-	containers, err := leader.QueryContainers()
+	containers, err := clnt.QueryContainers()
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't query containers")
 	}

--- a/tests/20-spark/check_spark.go
+++ b/tests/20-spark/check_spark.go
@@ -9,25 +9,18 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/quilt/api/client"
 	"github.com/quilt/quilt/util"
 )
 
 func main() {
-	clientGetter := getter.New()
-
-	clnt, err := clientGetter.Client(api.DefaultSocket)
+	clnt, err := client.New(api.DefaultSocket)
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't get quiltctl client.")
 	}
 	defer clnt.Close()
 
-	leader, err := clientGetter.LeaderClient(clnt)
-	if err != nil {
-		log.WithError(err).Fatal("FAILED, couldn't get leader client.")
-	}
-
-	containers, err := leader.QueryContainers()
+	containers, err := clnt.QueryContainers()
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't query containers.")
 	}

--- a/tests/30-mean/check_mean.go
+++ b/tests/30-mean/check_mean.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/quilt/api/client"
 	"github.com/quilt/quilt/db"
 
 	log "github.com/Sirupsen/logrus"
@@ -23,20 +23,13 @@ type Response struct {
 }
 
 func main() {
-	clientGetter := getter.New()
-
-	clnt, err := clientGetter.Client(api.DefaultSocket)
+	clnt, err := client.New(api.DefaultSocket)
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't get quiltctl client")
 	}
 	defer clnt.Close()
 
-	leader, err := clientGetter.LeaderClient(clnt)
-	if err != nil {
-		log.WithError(err).Fatal("FAILED, couldn't get leader client")
-	}
-
-	containers, err := leader.QueryContainers()
+	containers, err := clnt.QueryContainers()
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't query containers")
 	}

--- a/tests/40-stop/check_stop.go
+++ b/tests/40-stop/check_stop.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/quilt/api/client"
 	"github.com/quilt/quilt/minion/supervisor/images"
 
 	log "github.com/Sirupsen/logrus"
@@ -21,7 +21,7 @@ func main() {
 	log.Info("Sleeping thirty seconds for `quilt stop -containers` to take effect")
 	time.Sleep(30 * time.Second)
 
-	c, err := getter.New().Client(api.DefaultSocket)
+	c, err := client.New(api.DefaultSocket)
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't get quiltctl client")
 	}

--- a/tests/61-duplicate-cluster/check_duplicate_cluster.go
+++ b/tests/61-duplicate-cluster/check_duplicate_cluster.go
@@ -9,27 +9,19 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/quilt/api/client"
 )
 
 var connectionRegex = regexp.MustCompile(`Registering worker (\d+\.\d+\.\d+\.\d+:\d+)`)
 
 func main() {
-	clientGetter := getter.New()
-
-	clnt, err := clientGetter.Client(api.DefaultSocket)
+	clnt, err := client.New(api.DefaultSocket)
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't get quiltctl client.")
 	}
 	defer clnt.Close()
 
-	leader, err := clientGetter.LeaderClient(clnt)
-	if err != nil {
-		log.WithError(err).Fatal("FAILED, couldn't get leader client.")
-	}
-	defer leader.Close()
-
-	containers, err := leader.QueryContainers()
+	containers, err := clnt.QueryContainers()
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't query containers.")
 	}

--- a/tests/build-dockerfile/check_custom_images.go
+++ b/tests/build-dockerfile/check_custom_images.go
@@ -7,28 +7,20 @@ import (
 	"strings"
 
 	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/quilt/api/client"
 	"github.com/quilt/quilt/db"
 
 	log "github.com/Sirupsen/logrus"
 )
 
 func main() {
-	clientGetter := getter.New()
-
-	clnt, err := clientGetter.Client(api.DefaultSocket)
+	clnt, err := client.New(api.DefaultSocket)
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't get quiltctl client")
 	}
 	defer clnt.Close()
 
-	leader, err := clientGetter.LeaderClient(clnt)
-	if err != nil {
-		log.WithError(err).Fatal("FAILED, couldn't get leader client")
-	}
-	defer leader.Close()
-
-	containers, err := leader.QueryContainers()
+	containers, err := clnt.QueryContainers()
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't query containers")
 	}

--- a/tests/elasticsearch/check_elasticsearch.go
+++ b/tests/elasticsearch/check_elasticsearch.go
@@ -11,28 +11,20 @@ import (
 	"time"
 
 	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/quilt/api/client"
 	"github.com/quilt/quilt/db"
 
 	log "github.com/Sirupsen/logrus"
 )
 
 func main() {
-	clientGetter := getter.New()
-
-	clnt, err := clientGetter.Client(api.DefaultSocket)
+	clnt, err := client.New(api.DefaultSocket)
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't get quiltctl client")
 	}
 	defer clnt.Close()
 
-	leader, err := clientGetter.LeaderClient(clnt)
-	if err != nil {
-		log.WithError(err).Fatal("FAILED, couldn't get leader client")
-	}
-	defer leader.Close()
-
-	containers, err := leader.QueryContainers()
+	containers, err := clnt.QueryContainers()
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't query containers")
 	}

--- a/tests/etcd/check_etcd.go
+++ b/tests/etcd/check_etcd.go
@@ -6,27 +6,20 @@ import (
 	"strings"
 
 	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/quilt/api/client"
 	"github.com/quilt/quilt/db"
 
 	log "github.com/Sirupsen/logrus"
 )
 
 func main() {
-	clientGetter := getter.New()
-
-	clnt, err := clientGetter.Client(api.DefaultSocket)
+	clnt, err := client.New(api.DefaultSocket)
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't get quiltctl client")
 	}
 	defer clnt.Close()
 
-	leader, err := clientGetter.LeaderClient(clnt)
-	if err != nil {
-		log.WithError(err).Fatal("FAILED, couldn't get leader client")
-	}
-
-	containers, err := leader.QueryContainers()
+	containers, err := clnt.QueryContainers()
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't query containers")
 	}

--- a/tests/inbound-public/check_inbound_public.go
+++ b/tests/inbound-public/check_inbound_public.go
@@ -6,32 +6,25 @@ import (
 	"strconv"
 
 	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/quilt/api/client"
 	"github.com/quilt/quilt/db"
 
 	log "github.com/Sirupsen/logrus"
 )
 
 func main() {
-	clientGetter := getter.New()
-
-	clnt, err := clientGetter.Client(api.DefaultSocket)
+	clnt, err := client.New(api.DefaultSocket)
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't get quiltctl client")
 	}
 	defer clnt.Close()
 
-	leader, err := clientGetter.LeaderClient(clnt)
-	if err != nil {
-		log.WithError(err).Fatal("FAILED, couldn't get leader client")
-	}
-
-	containers, err := leader.QueryContainers()
+	containers, err := clnt.QueryContainers()
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't query containers")
 	}
 
-	connections, err := leader.QueryConnections()
+	connections, err := clnt.QueryConnections()
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't query connections")
 	}

--- a/tests/load-balancer/check_load_balancer.go
+++ b/tests/load-balancer/check_load_balancer.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/quilt/api/client"
 	"github.com/quilt/quilt/db"
 )
 
@@ -17,19 +17,13 @@ const (
 )
 
 func main() {
-	c, err := getter.New().Client(api.DefaultSocket)
+	c, err := client.New(api.DefaultSocket)
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't get local client")
 	}
 	defer c.Close()
 
-	leaderClient, err := getter.New().LeaderClient(c)
-	if err != nil {
-		log.WithError(err).Fatal("FAILED, couldn't get leader client")
-	}
-	defer leaderClient.Close()
-
-	containers, err := leaderClient.QueryContainers()
+	containers, err := c.QueryContainers()
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't get containers")
 	}

--- a/tests/outbound-public/check_outbound_public.go
+++ b/tests/outbound-public/check_outbound_public.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 
 	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/quilt/api/client"
 	"github.com/quilt/quilt/db"
 	"github.com/quilt/quilt/stitch"
 
@@ -13,26 +13,18 @@ import (
 )
 
 func main() {
-	clientGetter := getter.New()
-
-	clnt, err := clientGetter.Client(api.DefaultSocket)
+	clnt, err := client.New(api.DefaultSocket)
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't get quiltctl client")
 	}
 	defer clnt.Close()
 
-	leader, err := clientGetter.LeaderClient(clnt)
-	if err != nil {
-		log.WithError(err).Fatal("FAILED, couldn't get leader client")
-	}
-	defer leader.Close()
-
-	containers, err := leader.QueryContainers()
+	containers, err := clnt.QueryContainers()
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't query containers")
 	}
 
-	connections, err := leader.QueryConnections()
+	connections, err := clnt.QueryConnections()
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't query connections")
 	}

--- a/tests/zookeeper/check_zookeeper.go
+++ b/tests/zookeeper/check_zookeeper.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
+	"github.com/quilt/quilt/api/client"
 	"github.com/quilt/quilt/db"
 
 	log "github.com/Sirupsen/logrus"
@@ -14,20 +14,13 @@ import (
 )
 
 func main() {
-	clientGetter := getter.New()
-
-	clnt, err := clientGetter.Client(api.DefaultSocket)
+	clnt, err := client.New(api.DefaultSocket)
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't get quiltctl client")
 	}
 	defer clnt.Close()
 
-	leader, err := clientGetter.LeaderClient(clnt)
-	if err != nil {
-		log.WithError(err).Fatal("FAILED, couldn't get leader client")
-	}
-
-	containers, err := leader.QueryContainers()
+	containers, err := clnt.QueryContainers()
 	if err != nil {
 		log.WithError(err).Fatal("FAILED, couldn't query containers")
 	}


### PR DESCRIPTION
A recent commit in quilt/quilt made it so the daemon proxies requests to
the cluster, so clients don't need to get clients connected to the
leader and workers themselves.