### PR TITLE
google: Provide missing credentials field

### DIFF
--- a/config/gce.json.tmpl
+++ b/config/gce.json.tmpl
@@ -1,4 +1,5 @@
 {
+  "type": "service_account",
   "project_id": "{{gceProjectID}}",
   "private_key": "{{gcePrivateKey}}",
   "client_email": "{{gceClientEmail}}"


### PR DESCRIPTION
The recent vendor updates in Quilt caused ~/.gce/quilt.json to require
the "type" field. Without it, machines failed to boot.