### PR TITLE
blueprint: Remove unnecessary dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,14 +4,6 @@
   "main": "./tester.js",
   "license": "MIT",
   "dependencies": {
-    "@quilt/quilt": "quilt/quilt",
-    "@quilt/spark": "quilt/spark",
-    "@quilt/haproxy": "quilt/haproxy",
-    "@quilt/mongo": "quilt/mongo",
-    "@quilt/nodejs": "quilt/nodejs",
-    "@quilt/elasticsearch": "quilt/elasticsearch",
-    "@quilt/etcd": "quilt/etcd",
-    "@quilt/nginx": "quilt/nginx",
-    "@quilt/zookeeper": "quilt/zookeeper"
+    "@quilt/quilt": "quilt/quilt"
   }
 }


### PR DESCRIPTION
Those dependencies were only necessary when the integration tests lived
in this repository.