### PR TITLE
quilt-tester: Rename to integration-tester.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This repository contains a Quilt blueprint for a Jenkins deployment that tests
 It also contains a custom Docker image because we require some build tools and
 Jenkins plugins for our testing job.
 
-Note that by default the quilt-tester job has the `--preserve-failed` flag enabled.
+Note that by default we enable the `--preserve-failed` for the integration-tester.
 This flag leaves machines up if there were any test failures to facilitate debugging.
-Thus, if running locally, you may have to manually destroy the quilt-tester machines
-if your final test run ends in a failure.
+Thus, if running locally, you may have to manually destroy the integration-tester
+machines if your final test run ends in a failure.
 
 ## Deploying
 `tester.js` contains a module that creates a Jenkins service. It requires some

--- a/config/jenkins/integration-tester.xml
+++ b/config/jenkins/integration-tester.xml
@@ -63,7 +63,7 @@ mkdir ${WORKSPACE}/bin
 cp ${srcPath}/quilt_linux ${WORKSPACE}/bin/quilt
 chmod 755 ${WORKSPACE}/bin/quilt
 
-cd ${srcPath}/quilt-tester
+cd ${srcPath}/integration-tester
 go build .
 make tests
 
@@ -72,7 +72,7 @@ if [ "${USE_TLS}" = "true" ] ; then
   quilt -v setup-tls "${TLS_DIR}"
 fi
 
-./quilt-tester --preserve-failed -testRoot=./tests -junitOut=${WORKSPACE}/report.xml</command>
+./integration-tester --preserve-failed -testRoot=./tests -junitOut=${WORKSPACE}/report.xml</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jenkins.js
+++ b/jenkins.js
@@ -8,7 +8,7 @@ const path = require('path');
 // user) before starting Jenkins.
 const jenkinsStagingDir = '/tmp/files/';
 
-const releaserKeyPath = '~/jobs/quilt-tester/releaserKey';
+const releaserKeyPath = '~/jobs/integration-tester/releaserKey';
 
 /**
  * trimPrefix removes `prefix` from `str` if it begins with `prefix`.
@@ -74,9 +74,9 @@ function setupFiles(opts, scp) {
     readRel('config/jenkins/node.xml'));
   files.push(nodeConfig);
 
-  const knownHostsPath = '~/jobs/quilt-tester/known_hosts';
-  const quiltTesterConfig = new File('jobs/quilt-tester/config.xml',
-    applyTemplate(readRel('config/jenkins/quilt-tester.xml'),
+  const knownHostsPath = '~/jobs/integration-tester/known_hosts';
+  const quiltTesterConfig = new File('jobs/integration-tester/config.xml',
+    applyTemplate(readRel('config/jenkins/integration-tester.xml'),
       { slackTeam: opts.slackTeam,
         slackToken: opts.slackToken,
         slackChannel: opts.slackChannel,

--- a/tester-runner-example.js
+++ b/tester-runner-example.js
@@ -1,4 +1,4 @@
-// This file deploys a Jenkins instance running quilt-tester. It shows an example
+// This file deploys a Jenkins instance running integration-tester. It shows an example
 // of all paramters to `tester.New`. It uses a floating IP to automatically
 // configure `jenkinsUrl`.
 
@@ -21,7 +21,7 @@ const tester = new Tester({
   gcePrivateKey: 'privateKey',
   gceClientEmail: 'email',
   digitalOceanKey: 'key',
-  testingNamespace: 'quilt-tester',
+  testingNamespace: 'integration-tester',
   slackTeam: 'quilt-dev',
   slackChannel: '#testing',
   slackToken: 'secret',


### PR DESCRIPTION
This commit updates the reference to quilt/quilt-tester to be
quilt/integration-tester, to reflect the new location of the
integration tests, and also renames everything previously called
quilt-tester to integration-tester, for consistency.