### PR TITLE
integration-tester: Always run with TLS enabled

### DIFF
--- a/config/jenkins/integration-tester.xml
+++ b/config/jenkins/integration-tester.xml
@@ -27,11 +27,6 @@
           <description>The Quilt release to test.</description>
           <defaultValue>dev</defaultValue>
         </hudson.model.StringParameterDefinition>
-        <hudson.model.BooleanParameterDefinition>
-          <name>USE_TLS</name>
-          <description>Run Quilt with TLS enabled.</description>
-          <defaultValue>false</defaultValue>
-        </hudson.model.BooleanParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
@@ -42,7 +37,7 @@
   <triggers>
     <org.jenkinsci.plugins.parameterizedscheduler.ParameterizedTimerTrigger plugin="parameterized-scheduler@0.4">
       <spec></spec>
-      <parameterizedSpecification>0 0-23/3 * * * %PROVIDER=Amazon;SIZE=m3.medium;USE_TLS=true
+      <parameterizedSpecification>0 0-23/3 * * * %PROVIDER=Amazon;SIZE=m3.medium
 0 1-23/3 * * * %PROVIDER=Google;SIZE=n1-standard-1
 0 2-23/3 * * * %PROVIDER=DigitalOcean;SIZE=2gb</parameterizedSpecification>
     </org.jenkinsci.plugins.parameterizedscheduler.ParameterizedTimerTrigger>
@@ -67,10 +62,8 @@ cd ${srcPath}/integration-tester
 go build .
 make tests
 
-if [ "${USE_TLS}" = "true" ] ; then
-  export TLS_DIR="${WORKSPACE}/tls"
-  quilt -v setup-tls "${TLS_DIR}"
-fi
+export TLS_DIR="${WORKSPACE}/tls"
+quilt -v setup-tls "${TLS_DIR}"
 
 ./integration-tester --preserve-failed -testRoot=./tests -junitOut=${WORKSPACE}/report.xml</command>
     </hudson.tasks.Shell>


### PR DESCRIPTION
An upcoming change to Quilt will make it impossible to run without TLS.
This commit removes the option to test insecure Quilt deployments.