### PR TITLE
jenkins: Use Node version 6.9.0

### DIFF
--- a/config/jenkins/check-dependencies.xml
+++ b/config/jenkins/check-dependencies.xml
@@ -81,7 +81,7 @@ fi</command>
   </publishers>
   <buildWrappers>
     <jenkins.plugins.nodejs.NodeJSBuildWrapper plugin="nodejs@1.2.2">
-      <nodeJSInstallationName>node-7.10.0</nodeJSInstallationName>
+      <nodeJSInstallationName>node-6.9.0</nodeJSInstallationName>
     </jenkins.plugins.nodejs.NodeJSBuildWrapper>
     <org.jenkinsci.plugins.golang.GolangBuildWrapper plugin="golang@1.2">
       <goVersion>go-1.8</goVersion>

--- a/config/jenkins/integration-tester.xml
+++ b/config/jenkins/integration-tester.xml
@@ -125,7 +125,7 @@ manager.addShortText(&quot;${manager.build.buildVariables.get(&apos;PROVIDER&apo
     </hudson.plugins.ws__cleanup.PreBuildCleanup>
     <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.8"/>
     <jenkins.plugins.nodejs.NodeJSBuildWrapper plugin="nodejs@1.2.1">
-        <nodeJSInstallationName>node-7.10.0</nodeJSInstallationName>
+        <nodeJSInstallationName>node-6.9.0</nodeJSInstallationName>
     </jenkins.plugins.nodejs.NodeJSBuildWrapper>
     <org.jenkinsci.plugins.golang.GolangBuildWrapper plugin="golang@1.2">
       <goVersion>go-1.8</goVersion>

--- a/config/jenkins/node.xml
+++ b/config/jenkins/node.xml
@@ -8,12 +8,12 @@ and copying the resulting file at
 <jenkins.plugins.nodejs.tools.NodeJSInstallation_-DescriptorImpl plugin="nodejs@1.2.1">
     <installations class="jenkins.plugins.nodejs.tools.NodeJSInstallation-array">
         <jenkins.plugins.nodejs.tools.NodeJSInstallation>
-            <name>node-7.10.0</name>
+            <name>node-6.9.0</name>
             <properties>
                 <hudson.tools.InstallSourceProperty>
                     <installers>
                         <jenkins.plugins.nodejs.tools.NodeJSInstaller>
-                            <id>7.10.0</id>
+                            <id>6.9.0</id>
                             <npmPackagesRefreshHours>72</npmPackagesRefreshHours>
                         </jenkins.plugins.nodejs.tools.NodeJSInstaller>
                     </installers>


### PR DESCRIPTION
Version 7.10.0 is no longer available, causing the Jenkins builds to
fail. Furthermore, because we now explicitly support version 6.9.0, it's
good to test the earlier version in case we use any unsupported Node
features.